### PR TITLE
Nav buttons scroll horizontally

### DIFF
--- a/grapher/index.php
+++ b/grapher/index.php
@@ -1,4 +1,5 @@
 <?php include './version.php'; ?>
+<!DOCTYPE html>
 <html v=<?php echo $v; ?>>
 <head>
 	<!-- Google Analytics -->
@@ -319,7 +320,7 @@ $( document ).ready(function() {
 <div id=showhideleft onclick="showhideleft();" style='display:none;'>&#9664;</div>
 <div id=showhidebottom onclick="showhidebottom();" style='display:none;'>&#9660;</div>
 
-<div id=buttons><tr>
+<div id=buttons><div class="button-scroll-container">
 <div class=abutton id=fileshowhide>Data</div> <div class=spacer></div>
 <div class=abutton id=rowshowhide>Row</div> <div class=spacer></div>
 <div class=abutton id=colshowhide>Column</div> <div class=spacer></div>
@@ -327,7 +328,7 @@ $( document ).ready(function() {
 <div class=abutton id=teachingtoolsshowhide>Teaching Tools</div> <div class=spacer></div>
 <div class=abutton id=update>Save Changes</div> <div class=spacer></div>
 <div class=abutton id=wizardmenu>Display Explorer <span class="material-icons-outlined" style='font-size: inherit'>insights</span></div> <div class=spacer></div>
-<div class=abutton id=helper>Help</div>
+<div class=abutton id=helper>Help</div></div>
 </div>
 
 <div id=helppopup class="callout popup">

--- a/grapher/style.css
+++ b/grapher/style.css
@@ -106,12 +106,22 @@ table {
 #buttons {
 	position:absolute;
 	top:33px;
-	left:25px;
 	border: none;
 	height:25px;
 	background:none;
 	z-index:2;
 }
+
+.button-scroll-container {
+	position: static;
+	height:120%;
+	width: 98vw;
+	overflow-x:auto;
+	overflow-y: hidden;
+	white-space: nowrap;
+	scrollbar-width: thin;
+}
+
 .abutton {
     display: inline;
     position: relative;


### PR DESCRIPTION
Buttons at the top now overflow and scroll horizontally rather than wrapping. This doesn't happen when the browser window is full screen (not sure why). If you are full screen on a small display it will resize rather than overflow. However, if you are split screen with another window, it will overflow and the horizontal scroll will be used.

Adding <!DOCTYPE html> removes a warning from the output.

I have removed a <tr> tag that seems to have been unnecessary and not in a <table>